### PR TITLE
feat: implement blog page list

### DIFF
--- a/components/blogPostList.js
+++ b/components/blogPostList.js
@@ -15,12 +15,30 @@ const BlogPost = ({ id, date, title }) => {
   );
 };
 
-export default function BlogPostList({ allPostsData }) {
+export default function BlogPostList({ allPostsData, maxItems }) {
+  /**
+   * A dynamic list of blog posts.
+   * @param {Array} allPostsData - Required to render. Fetched from getSortedPostsData()
+   * @param {Number} maxItems - Optional. By default, all items will be displayed. If provided, only the first maxItems will be displayed, and a link to the blog will be displayed at the end.
+   */
+  let displayMore = false;
+  if (maxItems < allPostsData.length) {
+    allPostsData = allPostsData.slice(0, maxItems);
+    displayMore = true;
+  }
+
   return (
     <ul className={utilStyles.list}>
       {allPostsData.map(({ id, date, title }) => (
         <BlogPost id={id} date={date} title={title} key={id} />
       ))}
+      {displayMore ? (
+        <li className={`${utilStyles.listItem}`}>
+          <Link href="/blog">
+            <p>... and more</p>
+          </Link>
+        </li>
+      ) : null}
     </ul>
   );
 }

--- a/components/layout/layout.module.css
+++ b/components/layout/layout.module.css
@@ -39,7 +39,7 @@
 }
 
 .header h1 {
-  font-size: 3rem;
+  font-size: 3.5em;
   font-style: normal;
   font-weight: normal;
   margin: 0;

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -1,10 +1,29 @@
 import Layout from "../../components/layout/layout";
+import BlogPostList from "../../components/blogPostList";
+import { getSortedPostsData } from "../../lib/posts";
 
-export default function Projects() {
+export async function getStaticProps() {
+  const allPostsData = getSortedPostsData();
+  return {
+    props: {
+      allPostsData,
+    },
+  };
+}
+
+export default function Blog({ allPostsData }) {
   return (
     <Layout>
-      <h1>Blog</h1>
-      <p>🚧 under construction! 🚧</p>
+      <div
+        style={{
+          margin: "0 0 2em 0",
+          padding: "1em 0",
+          borderBottom: "1px solid black",
+        }}
+      >
+        <h1>Blog</h1>
+      </div>
+      <BlogPostList allPostsData={allPostsData} />
     </Layout>
   );
 }

--- a/pages/blog/index.js
+++ b/pages/blog/index.js
@@ -18,10 +18,11 @@ export default function Blog({ allPostsData }) {
         style={{
           margin: "0 0 2em 0",
           padding: "1em 0",
-          borderBottom: "1px solid black",
+          // borderBottom: "1px solid black",
         }}
       >
         <h1>Blog</h1>
+        {/* <p style={{ textAlign: "justify" }}></p> */}
       </div>
       <BlogPostList allPostsData={allPostsData} />
     </Layout>

--- a/pages/index.js
+++ b/pages/index.js
@@ -40,7 +40,7 @@ export default function Home({ allPostsData }) {
         </p>
       </section>
       <section className={`${utilStyles.padding1px}`}>
-        <BlogPostList allPostsData={allPostsData} />
+        <BlogPostList allPostsData={allPostsData} maxItems={10} />
       </section>
     </Layout>
   );

--- a/styles/Post.module.css
+++ b/styles/Post.module.css
@@ -1,5 +1,5 @@
 .title_container {
-  margin: 2em 0;
+  margin: 0 0 2em 0;
   padding: 1em 0;
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -14,6 +14,11 @@ body {
   animation-fill-mode: forwards;
 }
 
+h1 {
+  font-weight: normal;
+  font-size: 2em;
+}
+
 a {
   color: #37559e;
   text-decoration: none;


### PR DESCRIPTION
## Summary

This PR adds the `blogPostList` to the `/blog/` page. Not sure if I'm going to add anything else to this page, but there's also room for a short blurb at the top if I decide to write something small.

## Changes

- `blog/` - implement `getStaticProps` to fetch blog posts and display the `blogPostList`
- `components/blogPostList` - implement `maxItems` to display

Also contains some small styling changes